### PR TITLE
Typo fix: double for removed

### DIFF
--- a/templates/faq.html
+++ b/templates/faq.html
@@ -12,7 +12,7 @@
         <div class="question">
             <h4>What is the scoring methodology based on?</h4>
 
-            <p>It is extremely difficult to assign an objective value to a subjective question such as &ldquo;How bad is not implementing HTTP Strict Transport Security?&rdquo; This is complicated by the fact that what may be unnecessary for for one site &mdash; such as implementing Content Security Policy &mdash; might mitigate important risks for a different site.</p>
+            <p>It is extremely difficult to assign an objective value to a subjective question such as &ldquo;How bad is not implementing HTTP Strict Transport Security?&rdquo; This is complicated by the fact that what may be unnecessary for one site &mdash; such as implementing Content Security Policy &mdash; might mitigate important risks for a different site.</p>
             <p>The scores and grades offered by the Mozilla Observatory are designed to alert developers when they're not taking advantage of the latest web security features, as recommended in Mozilla's <a href="https://wiki.mozilla.org/Security/Guidelines/Web_Security">web security guidelines</a> and <a href="https://wiki.mozilla.org/Security/Server_Side_TLS">server side TLS guidelines</a>. Individual developers will need to determine which of these security technologies is right for their sites.</p>
         </div>
 


### PR DESCRIPTION
Hi there,

just a small typo fix: a double for in the text.

Kind regards,
Nicolas