### PR TITLE
navbar: Remove duplicate menu link for FAQ

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -32,7 +32,6 @@
                         <ul class="dropdown-menu">
                             <li><a href="https://github.com/mozilla/http-observatory/blob/master/httpobs/docs/api.md">API Documentation</a></li>
                             <li><a href="https://github.com/mozilla/http-observatory-website/">Contribute at GitHub</a></li>
-                            <li><a href="faq.html">Frequently Asked Questions</a></li>
                             <li><a href="terms.html">Legal &amp; Privacy</a></li>
                             <li><a href="https://github.com/mozilla/http-observatory/blob/master/httpobs/docs/scoring.md">Scoring Methodology</a></li>
                         </ul>


### PR DESCRIPTION
I just went with removing the dropdown link, could be either one :)