### PR TITLE
Enforce LF for the repository files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+*.css   text eol=lf
+*.html  text eol=lf
+*.js    text eol=lf
+*.json  text eol=lf
+*.md    text eol=lf
+*.py    text eol=lf
+*.svg   text eol=lf
+*.yml   text eol=lf


### PR DESCRIPTION
Now the files are identical across all OS'es and thus the SRI hashes too.

Fixes #50.

@marumari: this should be accompanied with updating render.py to always use LF too. But the important issue with SRI hashes being different is now fixed.