### PR TITLE
Updated hx structure of result page

### DIFF
--- a/templates/analyze.html
+++ b/templates/analyze.html
@@ -546,7 +546,7 @@
         </div>
 
         <div class="page-header" id="third-party-tests-page-header">
-            <h1>Third-party Scan Results</h1>
+            <h2 class="h1">Third-party Scan Results</h2>
         </div>
 
         <div id="third-party-tests">


### PR DESCRIPTION
Hello,

the Hx structure was going from h1 to h3, which is not correct.

I've replaced ```<h1>Third-party Scan Results</h1>``` to ```<h2 class="h1">Third-party Scan Results</h2>``` : it provides a correct structure and does not change anything to the layout of the page.

Cheers,
Nicolas