### PR TITLE
Scroll tables on mobile

### DIFF
--- a/analyze.html
+++ b/analyze.html
@@ -99,7 +99,7 @@
                                     <sup class="grade-letter-modifier" id="scan-grade-modifier"></sup>
                                 </span>
                             </div>
-                            <div class="col-md-8">
+                            <div class="col-md-8 table-responsive">
                                 <table class="table table-striped table-condensed pull-left scan-summary-table">
                                     <tr>
                                         <td>Host:</td>
@@ -252,7 +252,7 @@
                 <span class="h3">Test Scores</span>
             </div>
             <div class="panel-body">
-                <div class="row">
+                <div class="table-responsive">
                     <table class="table table-striped table-condensed pull-left scan-summary-table">
                         <tr>
                             <th>Test</th>
@@ -357,7 +357,7 @@
                 <button class="btn btn-default pull-right expandy-panel-button" type="button" data-toggle="collapse" data-target="#host-history-panel-body" aria-expanded="false" aria-controls="host-history-panel-body">Click to Expand</button>
             </div>
             <div class="panel-body collapse" id="host-history-panel-body">
-                <div class="row">
+                <div class="table-responsive">
                     <table class="table table-striped table-condensed pull-left" id="host-history-table">
                         <thead>
                             <tr>
@@ -378,7 +378,7 @@
                 <button class="btn btn-default pull-right expandy-panel-button" type="button" data-toggle="collapse" data-target="#server-headers-panel-body" aria-expanded="false" aria-controls="server-headers-panel-body">Click to Expand</button>
             </div>
             <div class="panel-body collapse" id="server-headers-panel-body">
-                <div class="row">
+                <div class="table-responsive">
                     <table class="table table-striped table-condensed pull-left" id="server-headers-table">
                     </table>
                 </div>
@@ -409,7 +409,7 @@
                                 <sup class="grade-letter-modifier" id="tlsobservatory-summary-grade-modifier"></sup>
                             </span>
                         </div>
-                        <div class="col-md-10">
+                        <div class="col-md-10 table-responsive">
                             <table class="table table-striped table-condensed pull-left tlsobservatory-summary-summary-table">
                                 <tr>
                                     <td>Host:</td>
@@ -522,7 +522,7 @@
                     <span class="h3">Cipher Suites</span>
                 </div>
                 <div class="panel-body">
-                    <div class="row">
+                    <div class="table-responsive">
                         <table class="table table-striped table-condensed pull-left" id="tlsobservatory-ciphers-table">
                             <thead>
                                 <tr>
@@ -626,7 +626,7 @@
                                 <sup class="grade-letter-modifier" id="ssllabs-grade-modifier"></sup>
                             </span>
                         </div>
-                        <div class="col-md-10">
+                        <div class="col-md-10 table-responsive">
                             <table class="table table-striped table-condensed ssllabs-summary-table">
                                 <tr>
                                     <td>Host:</td>
@@ -666,78 +666,80 @@
                             </span>
                         </div>
                         <div class="col-md-10">
-                            <table class="table table-striped table-condensed htbridge-summary-table">
-                                <tbody>
-                                    <tr>
-                                        <td>Host:</td>
-                                        <td><span id="htbridge-hostname"></span> <span class="deemphasize">(<span id="htbridge-ip"></span>)</span></td>
-                                    </tr>
-                                    <tr>
-                                        <td> </td>
-                                        <td> </td>
-                                    </tr>
-                                    <tr>
-                                        <td>Compliance:</td>
-                                        <td> </td>
-                                    </tr>
-                                    <tr>
-                                        <td class="p-l-3">PCI-DSS:</td>
-                                        <td id="htbridge-pci_dss_compliant"></td>
-                                    </tr>
-                                    <tr>
-                                        <td class="p-l-3">HIPAA:</td>
-                                        <td id="htbridge-hipaa_compliant"></td>
-                                    </tr>
-                                    <tr>
-                                        <td class="p-l-3">NIST:</td>
-                                        <td id="htbridge-nist_compliant"></td>
-                                    </tr>
-                                    <tr>
-                                        <td> </td>
-                                        <td> </td>
-                                    </tr>
-                                    <tr>
-                                        <td>Vulnerability Tests:</td>
-                                        <td> </td>
-                                    </tr>
-                                    <tr>
-                                        <td class="p-l-3"><a href="https://drownattack.com/">DROWN</a>:</td>
-                                        <td id="htbridge-drown"></td>
-                                    </tr>
-                                    <tr>
-                                        <td class="p-l-3"><a href="http://heartbleed.com/">Heartbleed</a>:</td>
-                                        <td id="htbridge-heartbleed"></td>
-                                    </tr>
-                                    <tr>
-                                        <td class="p-l-3">Insecure Renegotiation:</td>
-                                        <td id="htbridge-insecure_reneg"></td>
-                                    </tr>
-                                    <tr>
-                                        <td class="p-l-3"><a href="https://blog.qualys.com/ssllabs/2014/06/13/ssl-pulse-49-vulnerable-to-cve-2014-0224-14-exploitable">OpenSSL ChangeCipherSpec</a>:</td>
-                                        <td id="htbridge-cve_2014_0224"></td>
-                                    </tr>
-                                    <tr>
-                                        <td class="p-l-3"><a href="https://blog.cloudflare.com/yet-another-padding-oracle-in-openssl-cbc-ciphersuites/">OpenSSL Padding Oracle</a>:</td>
-                                        <td id="htbridge-cve_2016_2107"></td>
-                                    </tr>
-                                    <tr>
-                                        <td class="p-l-3"><a href="https://www.imperialviolet.org/2014/10/14/poodle.html">Poodle (SSLv3)</a>:</td>
-                                        <td id="htbridge-poodle_ssl"></td>
-                                    </tr>
-                                    <tr>
-                                        <td class="p-l-3"><a href="https://www.imperialviolet.org/2014/12/08/poodleagain.html">Poodle (TLS)</a>:</td>
-                                        <td id="htbridge-poodle_tls"></td>
-                                    </tr>
-                                    <tr>
-                                        <td> </td>
-                                        <td> </td>
-                                    </tr>
-                                    <tr>
-                                        <td>Complete Results:</td>
-                                        <td><span id="htbridge-url"></span></td>
-                                    </tr>
-                                </tbody>
-                            </table>
+                            <div class="table-responsive">
+                                <table class="table table-striped table-condensed htbridge-summary-table">
+                                    <tbody>
+                                        <tr>
+                                            <td>Host:</td>
+                                            <td><span id="htbridge-hostname"></span> <span class="deemphasize">(<span id="htbridge-ip"></span>)</span></td>
+                                        </tr>
+                                        <tr>
+                                            <td> </td>
+                                            <td> </td>
+                                        </tr>
+                                        <tr>
+                                            <td>Compliance:</td>
+                                            <td> </td>
+                                        </tr>
+                                        <tr>
+                                            <td class="p-l-3">PCI-DSS:</td>
+                                            <td id="htbridge-pci_dss_compliant"></td>
+                                        </tr>
+                                        <tr>
+                                            <td class="p-l-3">HIPAA:</td>
+                                            <td id="htbridge-hipaa_compliant"></td>
+                                        </tr>
+                                        <tr>
+                                            <td class="p-l-3">NIST:</td>
+                                            <td id="htbridge-nist_compliant"></td>
+                                        </tr>
+                                        <tr>
+                                            <td> </td>
+                                            <td> </td>
+                                        </tr>
+                                        <tr>
+                                            <td>Vulnerability Tests:</td>
+                                            <td> </td>
+                                        </tr>
+                                        <tr>
+                                            <td class="p-l-3"><a href="https://drownattack.com/">DROWN</a>:</td>
+                                            <td id="htbridge-drown"></td>
+                                        </tr>
+                                        <tr>
+                                            <td class="p-l-3"><a href="http://heartbleed.com/">Heartbleed</a>:</td>
+                                            <td id="htbridge-heartbleed"></td>
+                                        </tr>
+                                        <tr>
+                                            <td class="p-l-3">Insecure Renegotiation:</td>
+                                            <td id="htbridge-insecure_reneg"></td>
+                                        </tr>
+                                        <tr>
+                                            <td class="p-l-3"><a href="https://blog.qualys.com/ssllabs/2014/06/13/ssl-pulse-49-vulnerable-to-cve-2014-0224-14-exploitable">OpenSSL ChangeCipherSpec</a>:</td>
+                                            <td id="htbridge-cve_2014_0224"></td>
+                                        </tr>
+                                        <tr>
+                                            <td class="p-l-3"><a href="https://blog.cloudflare.com/yet-another-padding-oracle-in-openssl-cbc-ciphersuites/">OpenSSL Padding Oracle</a>:</td>
+                                            <td id="htbridge-cve_2016_2107"></td>
+                                        </tr>
+                                        <tr>
+                                            <td class="p-l-3"><a href="https://www.imperialviolet.org/2014/10/14/poodle.html">Poodle (SSLv3)</a>:</td>
+                                            <td id="htbridge-poodle_ssl"></td>
+                                        </tr>
+                                        <tr>
+                                            <td class="p-l-3"><a href="https://www.imperialviolet.org/2014/12/08/poodleagain.html">Poodle (TLS)</a>:</td>
+                                            <td id="htbridge-poodle_tls"></td>
+                                        </tr>
+                                        <tr>
+                                            <td> </td>
+                                            <td> </td>
+                                        </tr>
+                                        <tr>
+                                            <td>Complete Results:</td>
+                                            <td><span id="htbridge-url"></span></td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
                             <div class="row text-right">
                                 <img id="htbridge-logo" src="images/htbridge-logo.svg">
                             </div>
@@ -766,7 +768,7 @@
                                 <sup class="grade-letter-modifier" id="tlsimirhilfr-grade-modifier"></sup>
                             </span>
                         </div>
-                        <div class="col-md-10">
+                        <div class="col-md-10 table-responsive">
                             <table class="table table-striped table-condensed pull-left tlsimirhilfr-summary-table">
                                 <tr>
                                     <td>Host:</td>
@@ -824,7 +826,7 @@
                                 <sup class="grade-letter-modifier" id="securityheaders-grade-modifier"></sup>
                             </span>
                         </div>
-                        <div class="col-md-10">
+                        <div class="col-md-10 table-responsive">
                             <table class="table table-striped table-condensed pull-left securityheaders-summary-table">
                                 <tr>
                                     <td>Host:</td>
@@ -861,7 +863,7 @@
                                 <sup class="grade-letter-modifier" id="hstspreload-grade-modifier"></sup>
                             </span>
                         </div>
-                        <div class="col-md-10">
+                        <div class="col-md-10 table-responsive">
                             <table class="table table-striped table-condensed pull-left hstspreload-summary-table">
                                 <tr>
                                     <td>Host:</td>

--- a/analyze.html
+++ b/analyze.html
@@ -85,7 +85,7 @@
         <div class="page-header no-margin-top">
             <h1 class="no-margin-top">HTTP Observatory</h1>
         </div> -->
-        <div class="row equal">
+        <div class="row">
             <div class="col-md-6">
                 <div class="panel panel-primary summary" id="scan-summary">
                     <div class="panel-heading">


### PR DESCRIPTION
As proposed in #47 this PR forces the tables to scroll on mobile devices.

It also changes the first two panels to be stacked on mobile.

## Before
![localhost-8000-analyze html-host k-nut eu iphone 6 1](https://cloud.githubusercontent.com/assets/1096357/25587312/ca9a6ef8-2ea3-11e7-9730-4b96837b0a48.png)
![localhost-8000-analyze html-host k-nut eu iphone 6 2](https://cloud.githubusercontent.com/assets/1096357/25587313/cad906cc-2ea3-11e7-86f0-d2b9eee56f54.png)

## After
![localhost-8000-analyze html-host k-nut eu iphone 6](https://cloud.githubusercontent.com/assets/1096357/25587314/cae42836-2ea3-11e7-8a45-9728a1f3e546.png)

Unfortunately now on desktop there are vertical scrollbars for some tables. Those could be disabled by removing [this line](https://github.com/mozilla/http-observatory-website/blob/03b3e88f5bdc3fd0bd0ca54c2b8fc26eb83024c8/css/httpobs.css#L228) but I could not easily figure out how to do this locally since the page is using a checksummed version of the file.

Looking forward to your thoughts!
