### PR TITLE
specify requirements for running local devserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ $ git clone -b gh-pages https://github.com/mozilla/http-observatory-website.git
 However, it comes with a built-in web server that will automatically regenerate the SRI hashes:
 
 ```bash
-$ git clone gh-pages https://github.com/mozilla/http-observatory-website.git
+$ git clone https://github.com/mozilla/http-observatory-website.git
+$ pip install -r requirements.txt
 $ make devserver
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Jinja2==2.9.6
+livereload==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Jinja2==2.9.6
-livereload==2.5.1
+Jinja2
+livereload


### PR DESCRIPTION
When I wanted to run the local devserver python gave me some warnings about missing dependencies so I added those to a `requirements.txt` and adapted the run instructions to point out how to install those.

I also removed the `gh-pages` part from the clone instructions since that does not actually belong there as far as I can tell. 