### PR TITLE
Fix subresource integrity anchor

### DIFF
--- a/dist/analyze.html
+++ b/dist/analyze.html
@@ -223,7 +223,7 @@
                                         <p>We’ve noticed you’re using other domains to host your JavaScript code.</p>
                                         <p>Subresource Integrity guarantees that your site will stay safe even if one of those domains is compromised.</p>
                                         <ul>
-                                            <li><a href="https://infosec.mozilla.org/guidelines/web_security#subresource-Integrity">Mozilla Web Security Guidelines (Subresource Integrity)</a></li>
+                                            <li><a href="https://infosec.mozilla.org/guidelines/web_security#subresource-integrity">Mozilla Web Security Guidelines (Subresource Integrity)</a></li>
                                             <li><a href="https://www.srihash.org/">SRI Hash Generator</a></li>
                                         </ul>
                                     </div>
@@ -331,7 +331,7 @@
                                     <td><span class="glyphicon glyphicon-info-sign" data-toggle="popover" title="Referrer Policy" data-content="Referrer Policy can protect the privacy of your users by restricting the contents of the HTTP Referer header."></span></td>
                                 </tr>
                                 <tr>
-                                    <td><a href="https://infosec.mozilla.org/guidelines/web_security#subresource-Integrity">Subresource Integrity</a></td>
+                                    <td><a href="https://infosec.mozilla.org/guidelines/web_security#subresource-integrity">Subresource Integrity</a></td>
                                     <td class="glyphicon" id="tests-subresource-integrity-pass" aria-hidden="true"></td>
                                     <td id="tests-subresource-integrity-score"></td>
                                     <td id="tests-subresource-integrity-score-description"></td>

--- a/templates/analyze.html
+++ b/templates/analyze.html
@@ -162,7 +162,7 @@
                                         <p>We’ve noticed you’re using other domains to host your JavaScript code.</p>
                                         <p>Subresource Integrity guarantees that your site will stay safe even if one of those domains is compromised.</p>
                                         <ul>
-                                            <li><a href="https://infosec.mozilla.org/guidelines/web_security#subresource-Integrity">Mozilla Web Security Guidelines (Subresource Integrity)</a></li>
+                                            <li><a href="https://infosec.mozilla.org/guidelines/web_security#subresource-integrity">Mozilla Web Security Guidelines (Subresource Integrity)</a></li>
                                             <li><a href="https://www.srihash.org/">SRI Hash Generator</a></li>
                                         </ul>
                                     </div>
@@ -270,7 +270,7 @@
                                     <td><span class="glyphicon glyphicon-info-sign" data-toggle="popover" title="Referrer Policy" data-content="Referrer Policy can protect the privacy of your users by restricting the contents of the HTTP Referer header."></span></td>
                                 </tr>
                                 <tr>
-                                    <td><a href="https://infosec.mozilla.org/guidelines/web_security#subresource-Integrity">Subresource Integrity</a></td>
+                                    <td><a href="https://infosec.mozilla.org/guidelines/web_security#subresource-integrity">Subresource Integrity</a></td>
                                     <td class="glyphicon" id="tests-subresource-integrity-pass" aria-hidden="true"></td>
                                     <td id="tests-subresource-integrity-score"></td>
                                     <td id="tests-subresource-integrity-score-description"></td>


### PR DESCRIPTION
The subresource integrity anchor has a capital `I` instead of a
lowercase one, this stops the linked site from jumping to the correct
anchor tag.