### PR TITLE
Instruct search engines not to index the analysis page.

### DIFF
--- a/dist/analyze.html
+++ b/dist/analyze.html
@@ -7,6 +7,7 @@
     <meta name="author" content="April King">
     <meta name="description" content="Observatory by Mozilla is a project designed to help developers, system administrators, and security professionals configure their sites safely and securely.">
     <meta property="og:title" content="Observatory by Mozilla">
+    <meta property="robots" content="noindex">
 
     <!-- favicon stuff -->
     <link rel="apple-touch-icon" type="image/png" sizes="180x180" href="/images/favicons/apple-touch-icon-180x180.png">

--- a/templates/analyze.html
+++ b/templates/analyze.html
@@ -1,5 +1,9 @@
 {% extends "base.html" %}
 
+{% block meta %}
+    <meta name="robots" content="noindex">
+{% endblock %}
+
 {% block content %}
     <!-- Symantec certificate errors moved to the very top level -->
     <div class="hidden alert alert-danger text-center row" id="tlsobservatory-symantec-distrust-warning-june-2016">

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,6 +7,7 @@
     <meta name="author" content="{{ AUTHOR }}">
     <meta name="description" content="Observatory by Mozilla is a project designed to help developers, system administrators, and security professionals configure their sites safely and securely.">
     <meta property="og:title" content="Observatory by Mozilla">
+    {% block meta %}{% endblock %}
 
     <!-- favicon stuff -->
     <link rel="apple-touch-icon" type="image/png" sizes="180x180" href="/images/favicons/apple-touch-icon-180x180.png">


### PR DESCRIPTION
Add `<meta name="robots" content="noindex">` to both the static and the dynamic `analyze.html` pages. This required adding a second template block to `base.html` so that we can introduce the noindex header for this page only.