### PR TITLE
Fix third-party scanners parameter

### DIFF
--- a/js/httpobs.js
+++ b/js/httpobs.js
@@ -829,7 +829,7 @@ var Observatory = {
       }
 
       // if it succeeds, redirect to the analyze page
-      thirdParty = $('#scan-btn-third-party').prop('checked') ? '&third-party=false' : '';
+      thirdParty = $('#scan-btn-third-party').prop('checked') ? '?third-party=false' : '';
       window.location.href = '/analyze/' + url.host + thirdParty;
       return true;
     };


### PR DESCRIPTION
When ticking the `Don't scan with third-party scanners` checkbox, the parameter `third-party=false` was falsely interpreted as part of the domain name (and third-party scanners were triggered anyways):

![image](https://user-images.githubusercontent.com/495429/40315731-7d725ebc-5d1c-11e8-9a2d-7bd502403fae.png)

![image](https://user-images.githubusercontent.com/495429/40315748-87cbdc44-5d1c-11e8-980f-1534740021f0.png)
