### PR TITLE
Update the FAQ entry for securityheaders.com

### DIFF
--- a/templates/faq.html
+++ b/templates/faq.html
@@ -120,9 +120,9 @@ X-Content-Type-Options: nosniff</pre>
         </div>
 
         <div class="question">
-            <h3 class="h4">What is securityheaders.io?</h3>
+            <h3 class="h4">What is securityheaders.com?</h3>
 
-            <p><a href="https://securityheaders.io/">securityheaders.io</a> is an HTTP header analyzer run by <a href="https://twitter.com/Scott_Helme">@Scott_Helme</a> that performs scans similar to those done by the <a href="https://github.com/mozilla/http-observatory">Mozilla HTTP Observatory</a>, by testing HTTP headers. Why two sites that do the same thing? Well, when it comes to security, a second opinion can sure be handy!</p>
+            <p><a href="https://securityheaders.com/">securityheaders.com</a> is an HTTP header analyzer run by <a href="https://twitter.com/Scott_Helme">@Scott_Helme</a> that performs scans similar to those done by the <a href="https://github.com/mozilla/http-observatory">Mozilla HTTP Observatory</a>, by testing HTTP headers. Why two sites that do the same thing? Well, when it comes to security, a second opinion can sure be handy!</p>
         </div>
 
         <div class="question">


### PR DESCRIPTION
The tool was migrated from securityheaders.io to securityheaders.com a while back, and the scanner uses the new domain. So the FAQ must talk about the new domain too.