### PR TITLE
Wrapping of table label/content on small screens

### DIFF
--- a/src/css/_tablesaw.scss
+++ b/src/css/_tablesaw.scss
@@ -24,7 +24,16 @@ $tablesaw-width: 39.9375em;
   .tablesaw tbody tr:nth-of-type(1) {
     border: 0;
   }
+  .tablesaw-stack td .tablesaw-cell-label, .tablesaw-stack th .tablesaw-cell-label {
+    padding: 0;
+    width: 5em;
+  }
+  #cookies-table.tablesaw-stack td .tablesaw-cell-label, #cookies-table.tablesaw-stack th .tablesaw-cell-label {
+    width: 6em;
+  }
   .tablesaw tbody tr td span.tablesaw-cell-content {
+    max-width: none;
+    padding-left: 0.5em;
     font-weight: 400;
   }
   .tablesaw-cell-label::after {


### PR DESCRIPTION
https://twitter.com/craigfrancis/status/1105465073827528709

I've only been able to test this by editing the styles in the browser developer tools (on the live site), as I'm not in a position to install all of the dependencies, or process all of the SCSS files, so it can run locally... I also have to note that I'm not familiar with the "tablesaw" package... so hopefully this works :-)