### PR TITLE
Fix HSTS Preload results URL

### DIFF
--- a/src/js/third-party/hsts-preload.js
+++ b/src/js/third-party/hsts-preload.js
@@ -104,7 +104,7 @@ export const insert = async () => {
 export const load = async () => {
   var API_URL = 'https://hstspreload.org/api/v2/';
   const target = utils.getTarget();
-  const url = `https://hstspreload.org?domain?${target}`;
+  const url = `https://hstspreload.org?domain=${target}`;
 
   // Store the host and url
   state.target = target;


### PR DESCRIPTION
There appears to be a small mistake when creating the HSTS Preload results link that's rendered to the page.