### PR TITLE
Disallow indexing of analysis page

### DIFF
--- a/dist/robots.txt
+++ b/dist/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
 Disallow: /*.html$
+Disallow: /analyze*


### PR DESCRIPTION
Fixes the issue addressed by #152 with the `robots.txt` solution proposed in the thread.

Closes #152 (can you close a PR from a PR?)