### PR TITLE
changes the href of faq page's What is htbridge.com? section

### DIFF
--- a/src/templates/faq.html
+++ b/src/templates/faq.html
@@ -117,7 +117,7 @@ X-Content-Type-Options: nosniff</pre>
         <div class="question">
             <h3 class="h4">What is htbridge.com?</h3>
 
-            <p><a href="https://www.htbridge.com/ssl/">htbridge.com</a> is a TLS/SSL scanner by <a href="https://www.htbridge.com/">High-Tech Bridge</a> that analyzes your combination of cipher suites, handshake methods, supported protocols, and resistance against a variety of TLS attacks and produces a grade that reflects how secure those choices are. For sites that need it, it also tests your configuration against requirements set by HIPAA, NIST, and PCI-DSS.</p>
+            <p><a href="https://www.immuniweb.com/">htbridge.com</a> is a TLS/SSL scanner by <a href="https://www.htbridge.com/">High-Tech Bridge</a> that analyzes your combination of cipher suites, handshake methods, supported protocols, and resistance against a variety of TLS attacks and produces a grade that reflects how secure those choices are. For sites that need it, it also tests your configuration against requirements set by HIPAA, NIST, and PCI-DSS.</p>
         </div>
 
         <div class="question">


### PR DESCRIPTION
My pull request resolves issue #273 I have changed the link associated with What is htbridge.com?  section in the faq page as asked the domain name as changed I have added the link accordingly.